### PR TITLE
Fix isTocVisible for workday docs

### DIFF
--- a/connectors/workday/connection_setup.md
+++ b/connectors/workday/connection_setup.md
@@ -33,7 +33,7 @@ Workday REST API is used to work with custom objects in your Workday instance. I
 | Authorization endpoint | Authorization endpoint of the API Client you created to connect to Workato.<br>Only required if using custom objects. |
 | Token endpoint      | Token endpoint of the API Client you created to connect to Workato.<br>Only required if using custom objects. |
 
-### Register Integration System User
+## Register Integration System User
 We do not recommend using a user account of a worker to run integrations. There are a few reasons for this.
 
 Firstly, all operations performed by the integration will be logged under this worker instead of one dedicated for integration and workflow processes.
@@ -47,7 +47,7 @@ The ISU should have all the permissions needed to perform the required actions f
 ![403 error](/assets/images/connectors/workday/permission-error.png)
 *Error message when ISU does not have enough permission*
 
-### Create an ISU
+## Create an ISU
 
 <table class="unchanged rich-diff-level-one">
   <thead>
@@ -149,7 +149,7 @@ The ISU should have all the permissions needed to perform the required actions f
 
 Find out more about setting up an ISU [here](https://doc.workday.com/reader/Z9lz_01hqDMDg6NSf7wCBQ/esBDCh5D66sgBhIxmQ5U5g).
 
-### Register API Client
+## Register API Client
 This step is required only if you wish to work with custom objects in Workday. The Workday connector uses the Workday REST API, which uses an OAuth 2.0 for authentication. You need to register an API Client to allow connection to the REST API.
 
 ![Register API Client](/assets/images/connectors/workday/api-client-1.png)

--- a/connectors/workday/get-custom-objects.md
+++ b/connectors/workday/get-custom-objects.md
@@ -5,7 +5,7 @@ isTocVisible: true
 ---
 
 # Get custom objects
-You can extend Workday business objects by configuring custom objects. These custom objects are based standard Workday business objects and can be used to store additional information. This allows you to capture data unique to your organization in Workday. 
+You can extend Workday business objects by configuring custom objects. These custom objects are based standard Workday business objects and can be used to store additional information. This allows you to capture data unique to your organization in Workday.
 
 ## Get custom objects actions
 This action allows you to retrieve a custom object value of a specific Workday object.
@@ -15,7 +15,7 @@ For example, we are setting a new onboarding process for our employee. Every emp
 
 We can use this action to retrieve the status of a worker, to see if he/she has undergone the drug test.
 
-### Inputs
+## Inputs
 ![screen](/assets/images/connectors/workday/get-custom-object.png)
 *Inputs for get custom object action*
 
@@ -30,7 +30,7 @@ To retrieve the drug test status of Worker `1da8b422311b4929bfa4520f7f0b4e83`, w
 - Alias: `drugTested`
 - Parent object ID: `1da8b422311b4929bfa4520f7f0b4e83`
 
-### Outputs
+## Outputs
 
 ![Custom object output](/assets/images/connectors/workday/get-custom-object-output.png)
 *Custom object output*

--- a/connectors/workday/get_report.md
+++ b/connectors/workday/get_report.md
@@ -9,7 +9,7 @@ isTocVisible: true
 ## How to use
 Workday Report-as-a-Service is exposed as an action in Workato. This action will execute a run of the report, retrieve all data from that report and return them as an array. This data can be used in a recipe like any other actions. Learn how to set up a custom report [here](/connectors/workday/workday_raas.md).
 
-### Inputs
+## Inputs
 Provide the report URL to run and retrieve a report from Workday.
 
 ![Run report input](/assets/images/connectors/workday/raas_input.png)
@@ -22,7 +22,7 @@ Provide the report URL to run and retrieve a report from Workday.
 | Remove empty fields | If `Yes`, Workato will remove all `Null values` and leave the field empty.<br> Default is `Yes`. |
 | Additional fields | If some report fields (e.g. nested fields) do not appear in the action output, use this input field to define them. |
 
-### Configure report parameters and columns
+## Configure report parameters and columns
 
 ![Configure report parameters and columns manually](/assets/images/connectors/workday/custom-report-schema-input.png)
 *Configure report parameters and columns manually*
@@ -40,7 +40,7 @@ When you do that, additional input fields will appear for you to manually define
 | Report Parameters   | The filter parameters for your custom report. Input the **parameter alias** and the **value** according to how your custom report is configured. |
 | Report columns      | The output of your report. List the columns of your workday custom report. This schema will be converted into usable datapills for subsequently recipe actions on Workato. |
 
-### Outputs
+## Outputs
 The output of this action is presented as an array. Each element in this array corresponds to a row in the report. Similarly, each column in your report will be rendered as a field in the report output array.
 
 If you configured a custom schema in **Report column**, the custom report columns will be reflected as datapills.
@@ -48,7 +48,7 @@ If you configured a custom schema in **Report column**, the custom report column
 ![Outputs from Get report action](/assets/images/connectors/workday/raas_output.png)
 *Outputs from Get report action*
 
-### Use cases
+## Use cases
 
 #### Generate a custom CSV file
 A very simple use case for running and retrieving custom report data from Workday is to create a CSV file from the report. This can be done using the **CSV by Workato**.

--- a/connectors/workday/scheduled_report.md
+++ b/connectors/workday/scheduled_report.md
@@ -9,7 +9,7 @@ isTocVisible: true
 ## How to use
 This trigger is a combination of a Scheduler (advanced) and Workday RaaS action. When configured, it will run a report in Workday at pre-defined times and return results of the report in [batches](/features/batch-processing.md). The batch size limit is `200`.
 
-### Inputs
+## Inputs
 The required inputs are naturally a combination of both the Scheduler trigger and Workday RaaS actions.
 
 First, configure the Workday report to retrieve.
@@ -24,7 +24,7 @@ Second, configure the scheduler.
 ![Scheduled report input](/assets/images/connectors/workday/scheduled-report-input.png)
 *Scheduled report configuration*
 
-### Outputs
+## Outputs
 This trigger returns a number of fields:
 
 | Field                   | Description |

--- a/connectors/workday/update-custom-objects.md
+++ b/connectors/workday/update-custom-objects.md
@@ -17,7 +17,7 @@ We can use this action to assign a status to a worker. If a worker does not prev
 
 Otherwise, if this worker already has a **drugTested** object (e.g. `True`/`False`), this action will update the custom object with a new value.
 
-### Inputs
+## Inputs
 ![Create custom object action](/assets/images/connectors/workday/create-custom-object-action.png)
 *Create/update custom object action*
 
@@ -35,7 +35,7 @@ For example, for worker `6b36787a2e6301e185df0a95ff272a04` who has passed his dr
 - Custom object field (Drug tested): `True`
 - Parent object ID: `6b36787a2e6301e185df0a95ff272a04`
 
-### Outputs
+## Outputs
 There are no output for this action.
 
 You can check the custom object status of your worker with a [Get custom object action](/connectors/workday/get-custom-objects.md).


### PR DESCRIPTION
This add-on only accepts level 2 headers `##`, and there must be **2 or more** to populate the TOC