### PR TITLE
Rename `embedding` to `embedded`

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -756,4 +756,4 @@
       * [Key rotation](security/data-protection/encryption-key-management/key-rotation.md)
 * [Product Updates](product-updates.md)
 * [Contact us](contact-us.md)
-* [Embedding Connections](oem/embedding-connections.md) 
+* [Embedding Connections](oem/embedded-connections.md) 

--- a/book.json
+++ b/book.json
@@ -12,7 +12,7 @@
   ],
   "variables": {
     "shareablePages": [
-      "oem/embedding-connections.md"
+      "oem/embedded-connections.md"
     ]
   },
   "pluginsConfig": {

--- a/oem/embedded-connections.md
+++ b/oem/embedded-connections.md
@@ -1,14 +1,14 @@
 ---
-title: Embedding connections
+title: Embedded connections
 date: 2019-10-21 11:00:00 Z
 ---
 
-# Embedding connections
+# Embedded connections
 
 To use Connections widget you can add: 
 
 ```html
-<iframe src="https://workato.com/direct_link/embedding_connections/<connection_id>>?workato_dl_token=<jwt_token>"></iframe>
+<iframe src="https://workato.com/direct_link/embedded_connections/<connection_id>>?workato_dl_token=<jwt_token>"></iframe>
 ``` 
 
 Widget API works on postMessage. 
@@ -51,7 +51,7 @@ Is supported next types:
   </head>
   <body>
     <h4>Status: <span id="statusId"></span></h4>
-    <iframe id="workatoId" src="https://workato.com/direct_link/embedding_connections/<connection_id>>?workato_dl_token=<token>" style="width: 500px; height: 150px; border: 0"></iframe>
+    <iframe id="workatoId" src="https://workato.com/direct_link/embedded_connections/<connection_id>>?workato_dl_token=<token>" style="width: 500px; height: 150px; border: 0"></iframe>
   </body>
 </html>
 ```

--- a/oem/embedded-connections.md
+++ b/oem/embedded-connections.md
@@ -8,7 +8,7 @@ date: 2019-10-21 11:00:00 Z
 To use Connections widget you can add: 
 
 ```html
-<iframe src="https://workato.com/direct_link/embedded_connections/<connection_id>>?workato_dl_token=<jwt_token>"></iframe>
+<iframe src="https://workato.com/direct_link/embedded/connection/<connection_id>>?workato_dl_token=<jwt_token>"></iframe>
 ``` 
 
 Widget API works on postMessage. 
@@ -51,7 +51,7 @@ Is supported next types:
   </head>
   <body>
     <h4>Status: <span id="statusId"></span></h4>
-    <iframe id="workatoId" src="https://workato.com/direct_link/embedded_connections/<connection_id>>?workato_dl_token=<token>" style="width: 500px; height: 150px; border: 0"></iframe>
+    <iframe id="workatoId" src="https://workato.com/direct_link/embedded/connection/<connection_id>>?workato_dl_token=<token>" style="width: 500px; height: 150px; border: 0"></iframe>
   </body>
 </html>
 ```


### PR DESCRIPTION
Changed documentation to new url for embedded_connections