### PR TITLE
Remove links to hidden pages from sidebar

### DIFF
--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -2653,8 +2653,5 @@ module.exports = [
     ]
   },
   ['/product-updates', 'Product Updates'],
-  ['/contact-us', 'Contact us'],
-  ['/oem/embedded-connections', 'Embedded Connections'],
-  ['/oem/jwt-direct-linking', 'JWT Direct Linking'],
-  ['/oem/customer-managers', 'Customer managers']
+  ['/contact-us', 'Contact us']
 ];


### PR DESCRIPTION
This PR removes links to hidden pages (that should be available only by direct link) from the sidebar.