### PR TITLE
Fix issues with Algolia search bar

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -118,6 +118,12 @@ body {
     max-width: $maxContentSize;
   }
 
+  .algolia-search-wrapper {
+    .algolia-autocomplete {
+      width: 100%;
+    }
+  }
+
   {$contentClass} {
     color: #333;
     font-size: 16px;

--- a/docs/.vuepress/theme/components/Search.vue
+++ b/docs/.vuepress/theme/components/Search.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="Search">
-    <i class="fa fa-search" aria-hidden="true"></i>
+    <i class="fa fa-search" aria-hidden="true"/>
     <AlgoliaSearchBox v-if="algoliaSearchEnabled" :options="algoliaOptions"/>
-    <SearchBox/>
+    <SearchBox v-else/>
   </div>
 </template>
 


### PR DESCRIPTION
1. Hides original search bar if Algolia search is enabled
2. Fixes styles for Algolia search bar

![image](https://user-images.githubusercontent.com/302213/70907405-da7b3400-2019-11ea-95c3-78865afb0a42.png)
