### PR TITLE
Fix squashed logo on docs site on narrow screens

### DIFF
--- a/docs/.vuepress/theme/components/Header.vue
+++ b/docs/.vuepress/theme/components/Header.vue
@@ -100,7 +100,7 @@
     }
 
     &__logo {
-      height: 30px;
+      display: block;
       width: 184px;
 
       @media (max-width: $MQMobile) {


### PR DESCRIPTION
Fixes https://github.com/workato/docs/issues/980

**Desktop:**
![image](https://user-images.githubusercontent.com/302213/70907814-e4e9fd80-201a-11ea-85e2-d004e6762df0.png)

**Mobile:**
![image](https://user-images.githubusercontent.com/302213/70907836-f0d5bf80-201a-11ea-981d-b5823db6b39e.png)
