### PR TITLE
Update support_pills description

### DIFF
--- a/docs/developing-connectors/sdk/object-definition.md
+++ b/docs/developing-connectors/sdk/object-definition.md
@@ -195,7 +195,7 @@ Up until now, our sample code snippets have largely only included the basic para
         </tr>
         <tr>
             <td>support_pills</td>
-            <td>An optional boolean key. When true, this field doesn't allow datapills to be mapped to it. This parameter often doesn't need to be configured.
+            <td>An optional boolean key. When false, this field doesn't allow datapills to be mapped to it. This parameter often doesn't need to be configured.
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
When `false` it doesn't allow data pills to be mapped to it.

### Which issues does this fix?
<img width="893" alt="Screenshot 2020-01-08 at 20 47 50" src="https://user-images.githubusercontent.com/17669596/72002284-32433e80-3258-11ea-95cf-75c9feb48149.png">


### PR submission checklist
- [ ] Checked all content for grammatical errors (using Grammarly, for example)
- [ ] Added new files to `docs/vuepress/sidebar.js`
- [ ] Check for broken links
```bash
npm run check
```
