### PR TITLE
Correct typo in "create folder" endpoint parameter

### DIFF
--- a/docs/oem/oem-api/folders.md
+++ b/docs/oem/oem-api/folders.md
@@ -25,7 +25,7 @@ POST /api/managed_users/:id/folders
 
 | Name | Type | Description |
 |------|------|-------------|
-| folder_name | **string**<br>_required_ | Name of the folder. |
+| name | **string**<br>_required_ | Name of the folder. |
 {.api-input}
 
 #### Sample request

--- a/docs/oem/oem-api/folders.md
+++ b/docs/oem/oem-api/folders.md
@@ -31,7 +31,7 @@ POST /api/managed_users/:id/folders
 #### Sample request
 
 ```shell
-curl  -X POST https://www.workato.com/api/managed_users/91892/folders \
+curl  -X POST https://www.workato.com/api/managed_users/91892/folders?name=My%20Folder \
       -H 'x-user-email: <email>' \
       -H 'x-user-token: <token>'
 ```


### PR DESCRIPTION
It seems the docs contain an incorrect name for the "folder name" parameter to the "create folder" endpoint. When `folder_name` is used, the endpoint returns status code 400 and the response body says `"Missing parameter name"`. If `name` is used instead, it works as expected.

I also added that required parameter to the sample request on that page.

### PR submission checklist
- [x] Checked all content for grammatical errors (using Grammarly, for example) (N/A)
- [x] Added new files to `docs/vuepress/sidebar.js` (N/A)
- [x] Check for broken links (N/A)
```bash
npm run check
```
