### PR TITLE
Change delimiters for `markdown-it-attrs` plugin to `{:` and `:}` instead if `{` and `}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ All documents must be a Markdown files (`*.md`) which will be processed with [ma
 
 Here is the list of plugins that we use in addition to the [built-in addons](https://vuepress.vuejs.org/guide/markdown.html):
 
-- [markdown-it-attrs](https://github.com/arve0/markdown-it-attrs) - allows to set HTML attributes like `id` or `class` to any markdown element.
+- [markdown-it-attrs](https://github.com/arve0/markdown-it-attrs) - allows to set HTML attributes like `id` or `class` to any markdown element.<br>
+  Delimiters are set to `{:` and `:}` i.e. to set `foo` class to the header element you should write `# Header {: .foo :}`
 
 URLs to images (located in `/assets/images` directory) must start with `~@img` prefix e.g. to insert an image located at `/assets/images/foo.png` you need to write `![Foo](~@img/foo.png)`.

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -61,7 +61,11 @@ module.exports = {
       )
     },
     extendMarkdown: md => {
-      md.use(attributesPlugin)
+      md
+        .use(attributesPlugin, {
+          leftDelimiter: '{:',
+          rightDelimiter: ':}'
+        })
         .use(imageSizePlugin, {
           imagesDir: IMAGES_DIR,
           imagesAlias: IMAGES_ALIAS

--- a/docs/oem/oem-api/adapters.md
+++ b/docs/oem/oem-api/adapters.md
@@ -20,7 +20,7 @@ GET /api/integrations
 | Name | Type | Description |
 |------|------|-------------|
 | applications | **string**<br>_required_ | Comma separated connector identifiers. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 

--- a/docs/oem/oem-api/connections.md
+++ b/docs/oem/oem-api/connections.md
@@ -13,7 +13,7 @@ Use the following endpoints to retrieve and create the connections that belong t
 |------|---------|-------------|
 | GET  | [/api/managed_users/:managed_user_id/connections](#list-connections) | Returns a list of connections in OEM user's account. |
 | POST | [/api/managed_users/:id/connections](#create-connections) | Allows the OEM vendor to add a shell connection in a customer's account. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## List Connections
 
@@ -27,7 +27,7 @@ GET /api/managed_users/:managed_user_id/connections
 | Name | Type | Description |
 |------|------|-------------|
 | managed_user_id | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -81,7 +81,7 @@ POST /api/managed_users/:managed_user_id/connections
 | Name | Type | Description |
 |------|------|-------------|
 | managed_user_id | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
-{.api-input}
+{: .api-input :}
 
 ### Post parameters
 | Name | Type | Description |
@@ -89,7 +89,7 @@ POST /api/managed_users/:managed_user_id/connections
 | name | **string**<br>_optional_ | Name of the connection. Eg: 'Prod Salesforce connection'
 | provider | **string**<br>_required_ | Connector identifier. Eg: 'salesforce' |
 | input | **Hash**<br>_optional_ | Connection parameters. |
-{.api-input}
+{: .api-input :}
 
 For a list of providers and connection parameters, please view this [document](/oem/oem-api/connections-parameters.md).
 

--- a/docs/oem/oem-api/folders.md
+++ b/docs/oem/oem-api/folders.md
@@ -19,14 +19,14 @@ POST /api/managed_users/:id/folders
 | Name | Type | Description |
 |------|------|-------------|
 | managed_user_id | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
-{.api-input}
+{: .api-input :}
 
 ### Query parameters
 
 | Name | Type | Description |
 |------|------|-------------|
 | folder_name | **string**<br>_required_ | Name of the folder. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 

--- a/docs/oem/oem-api/managed-users.md
+++ b/docs/oem/oem-api/managed-users.md
@@ -19,7 +19,7 @@ All API endpoints listed here are OEM Vendor APIs and require the `oem_vendor` p
 | POST | [/api/managed_users/:id/member](#add-member-to-customer-account) | Add member to customer account. |
 | DELETE | [/api/managed_users/:id/member](#remove-member-from-customer-account) |  Remove member from customer account. |
 | GET  | [/api/managed_users/:id/connections](#list-customer-connections)| List customer connections. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Create customer account
 
@@ -38,7 +38,7 @@ POST /api/managed_users
 | plan_id | **string**<br>_optional_ | Plan id. Default plan id is used when not provided. |
 | external_id | **string**<br>_optional_ | External identifier for the OEM customer. |
 | origin_url | **string**<br>_optional_ | Applies to embedded OEM account customers. Provide a value if the embedded IFrame is hosted in a non-default origin page(E.g. customer specifc custom domains etc). Defaults to the origin configured at the account level. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -83,7 +83,7 @@ PUT /api/managed_users/:id
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
-{.api-input}
+{: .api-input :}
 
 
 ### Request body
@@ -94,7 +94,7 @@ PUT /api/managed_users/:id
 | notification_email | **string**<br>_required_  | Email for error notifications. |
 | external_id | **string**<br>_optional_ | External identifier for the OEM customer. |
 | origin_url | **string**<br>_optional_ | Applies to embedded OEM account customers. Provide a value if the embedded IFrame is hosted in a non-default origin page(E.g. customer specifc custom domains etc). Defaults to the origin configured at the account level. |
-{.api-input}
+{: .api-input :}
 
 User property is upated only if the request body contains the property. To clear the value of a property, set the property to `null` in the request body. 
 
@@ -142,7 +142,7 @@ GET /api/managed_users/:id
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -180,14 +180,14 @@ PUT /api/managed_users/:id/upgrade
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
-{.api-input}
+{: .api-input :}
 
 ### Request body
 
 | Name | Type | Description |
 |------|------|-------------|
 | plan_id | **string**<br>_optional_ | Plan id. Default plan id is used when not provided. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -224,7 +224,7 @@ PUT /api/managed_users/:id/downgrade
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -257,7 +257,7 @@ POST /api/managed_users/:id/member
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
-{.api-input}
+{: .api-input :}
 
 ### Request body
 
@@ -267,7 +267,7 @@ POST /api/managed_users/:id/member
 | oauth_id | **string**<br>_required_ | Identifier used for oauth. |
 | role_name | **string**<br>_optional_  | Role name. |
 | external_id | **string**<br>_optional_ | External identifier for the member. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -307,14 +307,14 @@ DELETE /api/managed_users/:id/member
 | Name | Type | Description |
 |------|------|-------------|
 | id | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
-{.api-input}
+{: .api-input :}
 
 ### Request body
 
 | Name | Type | Description |
 |------|------|-------------|
 | member_id | **string**<br>_required_ | Member id |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -349,7 +349,7 @@ GET /api/managed_users/:id/connections
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 

--- a/docs/oem/oem-api/oem-vendor-apis.md
+++ b/docs/oem/oem-api/oem-vendor-apis.md
@@ -31,14 +31,14 @@ Workato API supports sending request body with the `application/json` content-ty
 | `401` | Unauthorized | `{"message": "Unauthorized"}` |
 | `404` | Not found    | `{"message": "Not found"}`    |
 | `500` | Server error | `{"message":"Server error","id":"3188c2d0-29a4-4080-908e-582e7ed82580"}` |
-{.api-input}
+{: .api-input :}
 
 ## Connectors
 
 | Type |Resource | Description |
 |------|---------|-------------|
 | GET | [/api/integrations](/oem/oem-api/adapters.md#list-connector-metadata) | Query connector metadata.|
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Connections
 
@@ -46,21 +46,21 @@ Workato API supports sending request body with the `application/json` content-ty
 |------|---------|-------------|
 | GET  | [/api/managed_users/:managed_user_id/connections](/oem/oem-api/connections.md#list-connections) | Returns a list of connections in a customer account.|
 | POST | [/api/managed_users/:id/connections](/workato-api/connections.md) | Allows the OEM vendor to add a shell connection in a customer account. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Picklists
 
 | Type |Resource | Description |
 |------|---------|-------------|
 | POST | [/managed_users/:id/connections/:connection_id/pick_list](/oem/oem-api/picklists.md)) | Obtains a list of picklist values for a specified connection in an OEM customer account. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Folders
 
 | Type |Resource | Description |
 |------|---------|-------------|
 | POST | [/api/managed_users/:id/folders](/oem/oem-api/folders.md) | Creates a new folder in a customer account. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Manage customer accounts
 
@@ -73,7 +73,7 @@ Workato API supports sending request body with the `application/json` content-ty
 | PUT  | [/api/managed_users/:id/downgrade](/oem/oem-api/managed-users.md#downgrade-customer-account) | Downgrade customer account. |
 | POST | [/api/managed_users/:id/member](/oem/oem-api/managed-users.md#add-member-to-customer-account) | Add member to customer account. |
 | DELETE | [/api/managed_users/:id/member](/oem/oem-api/managed-users.md#remove-member-from-customer-account) |  Remove member from customer account. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Recipes
 
@@ -83,7 +83,7 @@ Workato API supports sending request body with the `application/json` content-ty
 | GET  | [/api/recipes/search](/oem/oem-api/recipes.md#search-for-public-recipes) | Search for public recipes. |
 | PUT  | [/api/managed_users/:managed_user_id/recipes/:recipe_id/start](/oem/oem-api/recipes.md#start-recipe-in-a-customer-account) | Start a recipe in a customer account. |
 | PUT  | [/api/managed_users/:managed_user_id/recipes/:recipe_id/stop](/oem/oem-api/recipes.md#stop-recipe-in-a-customer-account) | Stop a recipe in a customer account. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Recipe lifecycle management
 The endpoints listed below are OEM vendor only endpoints for importing a package into a customer account.
@@ -94,4 +94,4 @@ The APIs for exporting a package are available [here](/workato-api.md#recipe-lif
 |------|----------|-------------|
 | POST | [/api/managed_users/:id/imports](/oem/oem-api/recipe-lifecycle-management.md#import-package-into-a-customer-account) | Import package into a folder in a customer account. |
 | GET  | [/api/managed_users/:id/recipes](/oem/oem-api/recipe-lifecycle-management.md#get-package-status) | Get status of an imported package. |
-{.api-quick-reference}
+{: .api-quick-reference :}

--- a/docs/oem/oem-api/picklist-parameters.md
+++ b/docs/oem/oem-api/picklist-parameters.md
@@ -763,4 +763,4 @@ If a picklist requires parameter(s), the name of the parameter is specified here
 |zohocrm                    |vendor_picklist                        |                                  |
 |zohocrm                    |campaign_picklist                      |                                  |
 |zuora_forcecom             |all_sobjects                           |                                  |
-{.api-input}
+{: .api-input :}

--- a/docs/oem/oem-api/picklists.md
+++ b/docs/oem/oem-api/picklists.md
@@ -20,7 +20,7 @@ POST /managed_users/:id/connections/:connection_id/pick_list
 |------|------|-------------|
 | managed_user_id | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
 | connection_id | **string**<br>_required_ | ID of the connection. This can be found in the URL of the app connection or is the result of the [List connections](/oem/oem-api/connections.md#list-connections) endpoint.  |
-{.api-input}
+{: .api-input :}
 
 ### Body
 | Name | Type | Description |

--- a/docs/oem/oem-api/recipe-lifecycle-management.md
+++ b/docs/oem/oem-api/recipe-lifecycle-management.md
@@ -15,7 +15,7 @@ The APIs for exporting a package are available [here](/workato-api.md#recipe-lif
 |------|----------|-------------|
 | POST | [api/managed_users/:id/imports](#import-package-into-a-customer-account) | Import package into a folder in a customer account. |
 | GET  | [api/managed_users/:id/recipes](#get-package-status) | Get status of an imported package. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Import package into a customer account
 
@@ -36,7 +36,7 @@ The input (zip file) is a `application/octet-stream` payload containing package 
 | managed_user_id   | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
 | folder_id   | **string**<br>_required_ | Folder ID. |
 | restart_recipes | **boolean**<br>_optional_ | If `true`, it will allow the restarting of running recipes. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -72,7 +72,7 @@ GET /managed_users/:id/imports/:package_id
 |------|------|-------------|
 | managed_user_id   | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
 | package_id   | **string**<br>_required_ | Package ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 

--- a/docs/oem/oem-api/recipes.md
+++ b/docs/oem/oem-api/recipes.md
@@ -13,7 +13,7 @@ date: 2020-01-04 11:00:00 Z
 | GET  | [/api/recipes/search](#search-for-public-recipes) | Search for public recipes. |
 | PUT  | [/api/managed_users/:managed_user_id/recipes/:recipe_id/start](#start-recipe-in-a-customer-account) | Start a recipe in a customer account. |
 | PUT  | [/api/managed_users/:managed_user_id/recipes/:recipe_id/stop](#stop-recipe-in-a-customer-account) | Stop a recipe in a customer account. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## List recipes in a customer account
 
@@ -32,7 +32,7 @@ GET /api/managed_users/:id/recipes
 | page | **integer**<br>_optional_ | Page number (defaults to 1).|
 | per_page | **integer**<br>_optional_ | Page size (defaults to 10, maximum allowed is 100 per page). |
 | since_id | **integer**<br>_optional_ | Find recipes with ID less than the given ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -91,14 +91,14 @@ GET /api/recipes/search
 | boost_owned | **boolean**<br>_optional_ | If `true`, returned results will give priority to recipes in your account. Defaults to `false`. |
 | page | **integer**<br>_optional_ | Page number. Defaults to 0. |
 | per_page | **integer**<br>_optional_ | Page size. Defaults to 20, max 20. |
-{.api-input}
+{: .api-input :}
 
 ### Request body
 
 | Name | Type | Description |
 |------|------|-------------|
 | applications | **string**<br>_required_ | Comma separated connector identifiers (e.g: salesforce,service_now). |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -152,7 +152,7 @@ PUT /api/managed_users/:managed_user_id/recipes/:recipe_id/start
 |------|------|-------------|
 | managed_user_id   | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
 | recipe_id   | **integer**<br>_optional_ | Recipe ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -184,7 +184,7 @@ PUT /api/managed_users/:managed_user_id/recipes/:recipe_id/stop
 |------|------|-------------|
 | managed_user_id   | **string**<br>_required_ | OEM customer Account ID/External ID. <br>External id should be prefixed with a E(eg: EA2300) and the resulting id should be URL encoded. |
 | recipe_id   | **interger**<br>_optional_ | Recipe ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 

--- a/docs/security/ip-whitelists.md
+++ b/docs/security/ip-whitelists.md
@@ -39,7 +39,7 @@ The OPA makes an outbound connection to the Workato cloud's on-premise gateways 
 | `sg.workato.com` | 34.192.94.13<br>34.195.128.7<br>34.226.84.130 | 443 | Will be deprecated 5 April 2020 |
 | N/A | 52.206.58.244 | 443 | Deprecated 28 March 2018, not used in recent OPA versions |
 
-{.api-input}
+{: .api-input :}
 
 If your organization has strict outbound traffic rules, you will need to whitelist the OPA's access to the Workato cloud.
 

--- a/docs/workato-api.md
+++ b/docs/workato-api.md
@@ -27,21 +27,21 @@ Workato API supports sending request body with the `application/json` content-ty
 | `401` | Unauthorized | `{"message": "Unauthorized"}` |
 | `404` | Not found    | `{"message": "Not found"}`    |
 | `500` | Server error | `{"message":"Server error","id":"3188c2d0-29a4-4080-908e-582e7ed82580"}` |
-{.api-input}
+{: .api-input :}
 
 ## Connections
 
 | Type |Resource | Description |
 |------|---------|-------------|
 | GET | [/api/connections](/workato-api/connections.md) | List connections belonging to user. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Jobs
 
 | Type |Resource | Description |
 |------|---------|-------------|
 | GET | [/api/recipes/:recipe_id/jobs](/workato-api/jobs.md#list-jobs-from-a-recipe) | List jobs belonging to recipe. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Recipes
 
@@ -55,14 +55,14 @@ Workato API supports sending request body with the `application/json` content-ty
 | PUT  | [api/recipes/:id/start](/workato-api/recipes.md#start-recipe) | Start recipe. |
 | PUT  | [api/recipes/:id/stop](/workato-api/recipes.md#stop-recipe) | Stop recipe. |
 | DELETE | [api/recipes/:id](/workato-api/recipes.md#delete-recipe) | Delete recipe. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## User
 
 | Type | Resource | Description |
 |------|----------|-------------|
 | GET  | [api/users/me](/workato-api/users.md#get-user-details) | Get details of authenticated user. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Recipe lifecycle management
 
@@ -72,4 +72,4 @@ Workato API supports sending request body with the `application/json` content-ty
 | POST | [api/packages/import/:folder_id](/workato-api/recipe-lifecycle-management.md#import-package-into-a-folder) | Import package into a folder. |
 | GET  | [api/packages/:id](/workato-api/recipe-lifecycle-management.md#get-package-by-id) | Get package by ID. |
 | GET  | [api/packages/:id/download](/workato-api/recipe-lifecycle-management.md#download-package) | Download package. |
-{.api-quick-reference}
+{: .api-quick-reference :}

--- a/docs/workato-api/jobs.md
+++ b/docs/workato-api/jobs.md
@@ -24,7 +24,7 @@ GET /api/recipes/:id/jobs
 | failed | **boolean**<br>_(deprecated)_ | If `true`, returns failed jobs only. |
 | status | **string**<br>_optional_ | Filter by status - succeeded, failed, pending. |
 | rerun_jobs | **boolean**<br>_optional_ | If `true`, returns rerun jobs only. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 

--- a/docs/workato-api/recipe-lifecycle-management.md
+++ b/docs/workato-api/recipe-lifecycle-management.md
@@ -13,7 +13,7 @@ date: 2019-04-25 12:20:00 Z
 | POST | [/api/packages/import/:folder_id](#import-package-into-a-folder) | Import package into a folder. |
 | GET  | [/api/packages/:id](#get-package-by-id) | Get package by ID. |
 | GET  | [/api/packages/:id/download](#download-package) | Download a package. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Export package based on a manifest
 
@@ -30,7 +30,7 @@ This is an asynchronous request. Use [GET package by ID](#get-package-by-id) end
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **string**<br>_required_ | Export manifest ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -70,7 +70,7 @@ The input (zip file) is a `application/octet-stream` payload containing package 
 |------|------|-------------|
 | id   | **string**<br>_required_ | Folder ID. |
 | restart_recipes | **boolean**<br>_optional_ | If `true`, it will allow the restarting of running recipes. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -106,7 +106,7 @@ GET /api/packages/:id
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **string**<br>_required_ | Package ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -156,7 +156,7 @@ GET /api/packages/:id/download
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **string**<br>_required_ | Package ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 

--- a/docs/workato-api/recipes.md
+++ b/docs/workato-api/recipes.md
@@ -16,7 +16,7 @@ date: 2019-03-21 11:20:00 Z
 | PUT  | [/api/recipes/:id/start](#start-recipe) | Start recipe. |
 | PUT  | [/api/recipes/:id/stop](#stop-recipe) | Stop recipe. |
 | DELETE | [/api/recipes/:id](#delete-recipe) | Delete recipe. |
-{.api-quick-reference}
+{: .api-quick-reference :}
 
 ## Get recipe details
 
@@ -31,7 +31,7 @@ GET /api/recipes/:id
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **integer**<br>_required_ | Recipe ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -100,7 +100,7 @@ POST /api/recipes
 | code | **string**<br>_required_ | JSON string representing the recipe lines.
 | config | **string**<br>_required_ | JSON string representing the connection lines. |
 | recipe | **hash**<br>_optional_ | The hash of the recipe. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -138,7 +138,7 @@ PUT /api/recipes/:id
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **integer**<br>_required_ | Recipe ID. |
-{.api-input}
+{: .api-input :}
 
 ### Request body
 
@@ -148,7 +148,7 @@ PUT /api/recipes/:id
 | recipe[name] | **string**<br>_optional_ | Name of the recipe. |
 | recipe[code] | **string**<br>_optional_ | JSON string representing the recipe lines.
 | recipe[config] | **string**<br>_optional_ | JSON string representing the connection lines. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -202,7 +202,7 @@ GET /api/recipes
 | active | **string**<br>_optional_ | If `true`, returns running recipes. |
 | since_id | **integer**<br>_optional_ | Find recipes with ID less than the given ID. |
 | order | **string**<br>_optional_ | Set ordering method. Possible options: activity, default. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -259,7 +259,7 @@ PUT /api/recipes/:id/start
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **integer**<br>_optional_ | Recipe ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -290,7 +290,7 @@ PUT /api/recipes/:id/stop
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **integer**<br>_optional_ | Recipe ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 
@@ -321,7 +321,7 @@ DELETE /api/recipes/:id
 | Name | Type | Description |
 |------|------|-------------|
 | id   | **integer**<br>_optional_ | Recipe ID. |
-{.api-input}
+{: .api-input :}
 
 #### Sample request
 


### PR DESCRIPTION
Fixes #1073

Bug occurred because of this table:
```md
| Example                                  | Result                       |
| ---------------------------------------- | ---------------------------- |
| Hash: `{"pet" => "cat", "color" => "gray"}.to_json` | {"pet":"cat","color":"gray"} |
| Array: `["1","2","3"].to_json`           | ["1", "2", "3"]              |
```

`markdown-it-attrs` plugin parsed `{"pet":"cat","color":"gray"}` as an attributes list for `<tr>` element and browser was throwing an exception when trying to set an attribute with invalid name.