### PR TITLE
Typo inside the example table for to_currency_symbol

### DIFF
--- a/docs/formulas/string-formulas.md
+++ b/docs/formulas/string-formulas.md
@@ -605,8 +605,8 @@ Convert alpha-3 currency code or alpha-2/3 country code or country name to ISO42
 
 | Example                | Result |
 | ---------------------- | ------ |
-| `"GBR".to_currency_code` | "£"      |
-| `"USD".to_currency_code` | "$"      |
+| `"GBR".to_currency_symbol` | "£"      |
+| `"USD".to_currency_symbol` | "$"      |
 
 ---
 


### PR DESCRIPTION
Typo inside the example table for to_currency_symbol

current inputs: 

### Example

| Example                | Result |
| ---------------------- | ------ |
| `"GBR".to_currency_code` | "£"      |
| `"USD".to_currency_code` | "$"      |

--------------
Needs to be updated to: 

### Example

| Example                | Result |
| ---------------------- | ------ |
| `"GBR".to_currency_symbol` | "£"      |
| `"USD".to_currency_symbol` | "$"      |

### Which issues does this fix?
Fixes #12345

### PR submission checklist
- [x] Checked all content for grammatical errors (using Grammarly, for example)
- [ ] Added new files to `docs/vuepress/sidebar.js`
- [ ] Check for broken links
```bash
npm run check
```
