### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -33,6 +33,10 @@ module.exports = {
     require.resolve('./sidebar')
   ],
   themeConfig: {
+    algolia: {
+      apiKey: 'e9470947bfbf0d1cdac4bcfd3b2d9cc9',
+      indexName: 'workato'
+    },
     sidebar: require('./sidebar'),
     // Too long delay before scrolling to top and slow scrolling on pages with a lot of content
     // See issue https://github.com/workato/docs/issues/984


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.