### PR TITLE
Job timeout for step limit changed

### DIFF
--- a/docs/recipes/jobs.md
+++ b/docs/recipes/jobs.md
@@ -107,6 +107,6 @@ Rerun of a job will always use the latest version of the recipe. i.e. if the rec
 You can find out more about job reruns [here](rerun-job.md).
 
 ## Timeouts
-If a job or a single step is taking too long to execute, it will time out. The current limit is 25 seconds for a single step, and 90 minutes for a single job. The error message for a job that times out will explicitly mention the reason.
+If a job or a single step is taking too long to execute, it will time out. The current limit is 90 seconds for a single step, and 90 minutes for a single job. The error message for a job that times out will explicitly mention the reason.
 
 In these cases, you might have to further optimize your recipe to ensure that they don't hit this time limit.


### PR DESCRIPTION
Updated timeout limit for single step from 25s to 90s based on guru card https://app.getguru.com/card/T4kRganc/Max-Limits-for-Workato-features

### Which issues does this fix?
NA

### PR submission checklist
- [ ] Checked all content for grammatical errors (using Grammarly, for example)
- [ ] Added new files to `docs/vuepress/sidebar.js`
- [ ] Check for broken links
```bash
npm run check
```
